### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -33,7 +33,7 @@ import { PromptRegistry } from '../prompts/prompt-registry.js';
 import { MCPOAuthProvider } from '../mcp/oauth-provider.js';
 import { OAuthUtils } from '../mcp/oauth-utils.js';
 import { MCPOAuthTokenStorage } from '../mcp/oauth-token-storage.js';
-import { getErrorMessage } from '../utils/errors.js';
+import { getErrorMessage, sanitizeErrorMessage } from '../utils/errors.js';
 import { basename } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
@@ -415,10 +415,10 @@ export async function connectAndDiscover(
     if (mcpClient) {
       mcpClient.close();
     }
+    const rawErrorMsg = getErrorMessage(error);
+    const safeErrorMsg = sanitizeErrorMessage(rawErrorMsg);
     console.error(
-      `Error connecting to MCP server '${mcpServerName}': ${getErrorMessage(
-        error,
-      )}`,
+      `Error connecting to MCP server '${mcpServerName}': ${safeErrorMsg}`,
     );
     updateMCPServerStatus(mcpServerName, MCPServerStatus.DISCONNECTED);
   }

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -25,6 +25,24 @@ export function getErrorMessage(error: unknown): string {
   }
 }
 
+/**
+ * Sanitizes an error message by redacting sensitive OAuth-related fields.
+ * This function replaces occurrences of known sensitive keys with '[REDACTED]'.
+ */
+export function sanitizeErrorMessage(message: string): string {
+  // Redact common OAuth fields (client_id, client_secret, token, authorizationUrl, tokenUrl)
+  // This is a simple regex-based approach; adjust as needed for your context.
+  let sanitized = message;
+  sanitized = sanitized.replace(/(client_id=)[^&\s]+/gi, '$1[REDACTED]');
+  sanitized = sanitized.replace(/(client_secret=)[^&\s]+/gi, '$1[REDACTED]');
+  sanitized = sanitized.replace(/(token=)[^&\s]+/gi, '$1[REDACTED]');
+  sanitized = sanitized.replace(/(authorizationUrl=)[^&\s]+/gi, '$1[REDACTED]');
+  sanitized = sanitized.replace(/(tokenUrl=)[^&\s]+/gi, '$1[REDACTED]');
+  // Redact URLs that may contain sensitive query params
+  sanitized = sanitized.replace(/https?:\/\/[^\s]+/gi, '[REDACTED_URL]');
+  return sanitized;
+}
+
 export class ForbiddenError extends Error {}
 export class UnauthorizedError extends Error {}
 export class BadRequestError extends Error {}


### PR DESCRIPTION
Potential fix for [https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/7](https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/7)

To fix the problem, we should ensure that sensitive information is not logged in clear text. The best way to do this is to sanitize or redact error messages before logging them, especially when they may contain OAuth configuration details. We can implement a utility function (e.g., `sanitizeErrorMessage`) that removes or masks sensitive fields from error messages. In the catch block of `connectAndDiscover`, we should use this function before logging the error.

Specifically:
- In `packages/core/src/tools/mcp-client.ts`, update the catch block in `connectAndDiscover` to use a sanitization function before logging the error.
- Implement a `sanitizeErrorMessage` function in `packages/core/src/utils/errors.ts` that redacts known sensitive fields (e.g., URLs, client IDs, secrets) from error messages.
- Import and use this function in `mcp-client.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
