### PR TITLE
Potential fix for code scanning alert no. 8: Shell command built from environment values

### DIFF
--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { exec, execSync, spawn, type ChildProcess } from 'node:child_process';
+import { exec, execSync, execFileSync, spawn, type ChildProcess } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -378,10 +378,16 @@ export async function start_sandbox(
           console.error(`using ${projectSandboxDockerfile} for sandbox`);
           buildArgs += `-f ${path.resolve(projectSandboxDockerfile)} -i ${image}`;
         }
-        execSync(
-          `cd ${gcRoot} && node scripts/build_sandbox.js -s ${buildArgs}`,
+        // Split buildArgs into an array for execFileSync
+        const buildArgsArray = buildArgs
+          ? ['-s', ...buildArgs.split(' ').filter(Boolean)]
+          : ['-s'];
+        execFileSync(
+          'node',
+          ['scripts/build_sandbox.js', ...buildArgsArray],
           {
             stdio: 'inherit',
+            cwd: gcRoot,
             env: {
               ...process.env,
               GEMINI_SANDBOX: config.command, // in case sandbox is enabled via flags (see config.ts under cli package)


### PR DESCRIPTION
Potential fix for [https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/8](https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/8)

To fix the problem, we should avoid constructing a shell command string that includes untrusted or environment-derived values. Instead, we should use the `execFileSync` API, which allows us to pass command arguments as an array, avoiding shell interpretation. Specifically, instead of using `execSync` with a shell command string, we should use `execFileSync` to run `node` with the script and arguments directly, and use `process.chdir(gcRoot)` to change the working directory before running the command, or use the `cwd` option of `execFileSync`. This approach ensures that any special characters in file paths are handled safely and not interpreted by the shell.

**Required changes:**
- Replace the use of `execSync` with a shell command string with `execFileSync`, passing the script and its arguments as an array.
- Use the `cwd` option to set the working directory to `gcRoot` instead of using `cd` in the shell command.
- Import `execFileSync` from `node:child_process` if not already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
