### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -84,10 +84,18 @@ class WebFetchToolInvocation extends BaseToolInvocation<
     let url = urls[0];
 
     // Convert GitHub blob URL to raw URL
-    if (url.includes('github.com') && url.includes('/blob/')) {
-      url = url
-        .replace('github.com', 'raw.githubusercontent.com')
-        .replace('/blob/', '/');
+    try {
+      const parsedUrl = new URL(url);
+      if (
+        (parsedUrl.host === 'github.com' || parsedUrl.host.endsWith('.github.com')) &&
+        parsedUrl.pathname.includes('/blob/')
+      ) {
+        url = url
+          .replace('github.com', 'raw.githubusercontent.com')
+          .replace('/blob/', '/');
+      }
+    } catch (e) {
+      // If URL parsing fails, leave url unchanged
     }
 
     try {


### PR DESCRIPTION
Potential fix for [https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/1](https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/1)

To fix the problem, the code should parse the URL and check the host explicitly, rather than using a substring check. Specifically, instead of `url.includes('github.com')`, the code should use the `URL` constructor to parse the URL and then check if the host is exactly `github.com` or a known subdomain (if desired). This change should be made in the `executeFallback` method, where the GitHub blob URL conversion logic is implemented. No additional dependencies are required, as the standard `URL` class is available in Node.js and modern browsers. The fix involves replacing the substring check with a host check using the parsed URL object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
