### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -252,7 +252,7 @@ export class MCPOAuthProvider {
       server.on('error', reject);
       server.listen(this.REDIRECT_PORT, () => {
         console.log(
-          `OAuth callback server listening on port ${this.REDIRECT_PORT}`,
+          'OAuth callback server listening for authentication response.',
         );
       });
 


### PR DESCRIPTION
Potential fix for [https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/5](https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/5)

To fix the problem, we should avoid logging the actual port number used for the OAuth callback server. Instead, we can log a generic message indicating that the callback server is listening, without specifying the port. This prevents potential exposure of sensitive configuration details, especially if the port is user-controlled or varies per environment. The change should be made in `packages/core/src/mcp/oauth-provider.ts`, specifically on line 255, where the log statement currently includes the port number. No additional imports or method definitions are required; simply update the log message to remove the port number.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
