### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -160,10 +160,19 @@ ${textContent}
     // Perform GitHub URL conversion here to differentiate between user-provided
     // URL and the actual URL to be fetched.
     const urls = extractUrls(this.params.prompt).map((url) => {
-      if (url.includes('github.com') && url.includes('/blob/')) {
-        return url
-          .replace('github.com', 'raw.githubusercontent.com')
-          .replace('/blob/', '/');
+      try {
+        const parsed = new URL(url);
+        // Check for github.com or subdomains (e.g., gist.github.com)
+        if (
+          (parsed.hostname === 'github.com' || parsed.hostname.endsWith('.github.com')) &&
+          parsed.pathname.includes('/blob/')
+        ) {
+          return url
+            .replace(parsed.hostname, 'raw.githubusercontent.com')
+            .replace('/blob/', '/');
+        }
+      } catch (e) {
+        // If URL parsing fails, fall back to original logic (or skip transformation)
       }
       return url;
     });


### PR DESCRIPTION
Potential fix for [https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/2](https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/2)

To fix the problem, we should parse the URL using the standard `URL` class and check the `hostname` property to ensure it matches `github.com` or a valid subdomain (e.g., `gist.github.com`). This avoids false positives from substring matches in other URL components. The fix should be applied in the block where the GitHub URL conversion is performed (lines 162–169). We will need to handle invalid URLs gracefully (e.g., with a try/catch). No new dependencies are required, as the `URL` class is built-in.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
