### PR TITLE
Potential fix for code scanning alert no. 17: Regular expression injection

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,8 @@
     "strip-ansi": "^7.1.0",
     "undici": "^7.10.0",
     "ws": "^8.18.0",
-    "@xterm/headless": "5.5.0"
+    "@xterm/headless": "5.5.0",
+    "safe-regex": "^2.1.1"
   },
   "optionalDependencies": {
     "@lydell/node-pty": "1.1.0",

--- a/packages/core/src/tools/grep.ts
+++ b/packages/core/src/tools/grep.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import { EOL } from 'os';
 import { spawn } from 'child_process';
 import { globStream } from 'glob';
+import safeRegex from 'safe-regex';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
@@ -625,6 +626,10 @@ export class GrepTool extends BaseDeclarativeTool<GrepToolParams, ToolResult> {
       new RegExp(params.pattern);
     } catch (error) {
       return `Invalid regular expression pattern provided: ${params.pattern}. Error: ${getErrorMessage(error)}`;
+    }
+    // Prevent catastrophic (ReDoS-prone) regexes
+    if (!safeRegex(params.pattern)) {
+      return `The regular expression pattern provided is potentially unsafe or vulnerable to ReDoS (catastrophic backtracking): ${params.pattern}`;
     }
 
     // Only validate path if one is provided


### PR DESCRIPTION
Potential fix for [https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/17](https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/17)

To fix the regular expression injection (DoS) vulnerability without breaking the existing functionality, we must ensure that untrusted user input is only used as a literal substring in a regular expression, or, if full regex is required, prevent catastrophic regex use. If `pattern` is only meant to match literal strings, we would sanitize the pattern using Lodash's `_.escapeRegExp` before using it. However, the documentation and schema suggest that `pattern` IS designed to allow arbitrary regex syntax. In this case, the best approach is to use a library that provides safer regex evaluation (e.g., `safe-regex` to check for catastrophic regexes or to limit their complexity), or at minimum, validate and reject unsafe patterns.

Since the code does not currently depend on any library for regex safety, and the task only allows edits within the shown file (`packages/core/src/tools/grep.ts`), the most implementable fix is to use the `safe-regex` package to check if the regex is potentially unsafe before constructing it and return a helpful error message if not.

This change should be made in the `validateToolParamValues` method of the `GrepTool` class. We need to add a dependency on `safe-regex`, import it, and use it to validate the user-supplied pattern after catching exceptions from `RegExp`. If it is unsafe, return an error.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
