### PR TITLE
Potential fix for code scanning alert no. 18: Overly permissive regular expression range

### DIFF
--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -171,7 +171,7 @@ export class LoopDetectionService {
       /(^|\n)\s*[*-+]\s/.test(content) || /(^|\n)\s*\d+\.\s/.test(content);
     const hasHeading = /(^|\n)#+\s/.test(content);
     const hasBlockquote = /(^|\n)>\s/.test(content);
-    const isDivider = /^[+-_=*\u2500-\u257F]+$/.test(content);
+    const isDivider = /^[+\-_=*\u2500-\u257F]+$/.test(content);
 
     if (
       numFences ||


### PR DESCRIPTION
Potential fix for [https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/18](https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/18)

The best way to fix this problem is to escape the dash or move it to the beginning or end of the character class, so it is interpreted as the literal dash instead of as a range. For this case, `[+-_=*\u2500-\u257F]` should be rewritten so `-` does NOT start a range unintentionally. To fix, change the regex to `/^[+\-_=*\u2500-\u257F]+$/`, which escapes the dash (`\-`), making it a literal, so only the intended characters (`+`, `-`, `_`, `=`, `*`, as well as the Unicode range `\u2500-\u257F`) are matched. The change only needs to be made to line 174 in `packages/core/src/services/loopDetectionService.ts`.

No imports or new methods are required. Just one code edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
