### PR TITLE
Potential fix for code scanning alert no. 9: Unsafe shell command constructed from library input

### DIFF
--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -183,7 +183,6 @@ export async function openDiff(
         return new Promise((resolve, reject) => {
           const childProcess = spawn(diffCommand.command, diffCommand.args, {
             stdio: 'inherit',
-            shell: true,
           });
 
           childProcess.on('close', (code) => {


### PR DESCRIPTION
Potential fix for [https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/9](https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/9)

To fix this, avoid using `shell: true` when calling `spawn` (and other child_process methods), as this disables automatic escaping and argument separation. Pass the executable as the `command` argument, and the arguments as an array, with `shell: false` (the default). If you must use the shell, arguments need to be carefully quoted/escaped using a library like `shell-quote`. In this case, as shown in the code, you're already passing the command and arguments separately, so you can simply omit `shell: true` and safe argument passing will be enforced. Therefore, the best fix is to remove `shell: true` from the options object on line 186 for the `spawn` call in the GUI editors codepath. You do not need additional dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
