### PR TITLE
Potential fix for code scanning alert no. 14: Unsafe shell command constructed from library input

### DIFF
--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { execSync, spawn } from 'node:child_process';
+import { execSync, execFileSync, spawn } from 'node:child_process';
 
 export type EditorType =
   | 'vscode'
@@ -204,10 +204,10 @@ export async function openDiff(
         // Use execSync for terminal-based editors
         const command =
           process.platform === 'win32'
-            ? `${diffCommand.command} ${diffCommand.args.join(' ')}`
-            : `${diffCommand.command} ${diffCommand.args.map((arg) => `"${arg}"`).join(' ')}`;
+            ? (() => { /* Windows: use execFileSync with args */ return {cmd: diffCommand.command, args: diffCommand.args}; })()
+            : (() => { /* Unix: use execFileSync with args */ return {cmd: diffCommand.command, args: diffCommand.args}; })();
         try {
-          execSync(command, {
+          execFileSync(command.cmd, command.args, {
             stdio: 'inherit',
             encoding: 'utf8',
           });


### PR DESCRIPTION
Potential fix for [https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/14](https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/14)

The correct fix is to avoid passing a single string composed of potentially unsafe input to the shell (i.e., to `execSync(commandString, ...)`). Instead, use the safer child process API that allows the command and its arguments to be specified as an array, which avoids shell expansion and special-character interpretation. In Node.js, this is accomplished by calling `execFileSync` instead of `execSync`; `execFileSync(command, args, options)` launches the executable directly, passing the arguments array, free from shell injection vulnerabilities.

**Summary of changes:**
- Import `execFileSync` from `node:child_process` (or use destructuring as current).
- In the relevant case block for terminal-based editors (vim, emacs, neovim), use `execFileSync(diffCommand.command, diffCommand.args, options)` instead of string-building and calling `execSync`.
- No need to make changes outside this region; the interface remains the same for the rest of the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
