### PR TITLE
Potential fix for code scanning alert no. 19: Use of password hash with insufficient computational effort

### DIFF
--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -12,6 +12,7 @@ import * as fs from 'node:fs';
 export const GEMINI_DIR = '.gemini';
 export const GOOGLE_ACCOUNTS_FILENAME = 'google_accounts.json';
 const TMP_DIR_NAME = 'tmp';
+const STATIC_PROJECT_HASH_SALT = 'gemini-secure-salt-v1'; // Change this seed value if desired
 
 export class Storage {
   private readonly targetDir: string;
@@ -79,7 +80,13 @@ export class Storage {
   }
 
   private getFilePathHash(filePath: string): string {
-    return crypto.createHash('sha256').update(filePath).digest('hex');
+    // Use PBKDF2 with a fixed salt for deterministic, but expensive, hashing
+    const salt = STATIC_PROJECT_HASH_SALT;
+    const iterations = 100_000;
+    const keylen = 32; // 32 bytes = 64 hex chars, matches SHA256 output
+    const digest = 'sha256';
+    const hashBuffer = crypto.pbkdf2Sync(filePath, salt, iterations, keylen, digest);
+    return hashBuffer.toString('hex');
   }
 
   getHistoryDir(): string {


### PR DESCRIPTION
Potential fix for [https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/19](https://github.com/akadevbarki76-collab/gemini-cli/security/code-scanning/19)

To fix the problem, replace the use of a generic hash function (`sha256`) on user-controllable or tainted input with a password hashing function that is designed to be computationally expensive and resistant to brute-force attacks (such as `bcrypt`, `scrypt`, PBKDF2, or Argon2). Since Node.js ships with a built-in implementation of PBKDF2 in the `crypto` module, we should use `crypto.pbkdf2Sync()` with reasonable, strong parameters (e.g., a random salt, 100,000+ iterations). If external libraries are allowed, `bcrypt` could be used via the `bcrypt` npm package.

The fix should:
- Update the `getFilePathHash` method in `packages/core/src/config/storage.ts` to use PBKDF2 rather than plain SHA256.
- Introduce a randomly generated salt to make the hash output unpredictable (may need to store salt if hashing must be deterministic, otherwise use a stable salt such as the application's install ID, etc.).
- Update imports if needed.
- Use parameters recommended for password hashing (e.g., 100,000 iterations, 64-byte output).
- If the hash must be deterministic between runs (e.g., for mapping identical file paths to the same hash), use an application-level static salt.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
